### PR TITLE
threadpoolctl 3.5.0 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,19 +20,8 @@ requirements:
     - flit-core >2,<4
   run:
     - python
-
-{% set skip_tests = "" %}
-{% set skip_tests = skip_tests + "test_controller_info_actualized or " %}
-{% set skip_tests = skip_tests + "test_threadpool_limits_by_prefix or " %}
-{% set skip_tests = skip_tests + "test_threadpool_limits_by_prefix or " %}
-{% set skip_tests = skip_tests + "test_set_threadpool_limits_by_api or " %}
-{% set skip_tests = skip_tests + "test_threadpool_limits_function_with_side_effect or " %}
-{% set skip_tests = skip_tests + "test_threadpool_limits_manual_restore or " %}
-{% set skip_tests = skip_tests + "test_threadpool_controller_limit or " %}
-{% set skip_tests = skip_tests + "test_get_params_for_sequential_blas_under_openmp or " %}
-{% set skip_tests = skip_tests + "test_nested_limits or " %}
-{% set skip_tests = skip_tests + "test_threadpool_controller_as_decorator or " %}
-{% set skip_tests = skip_tests + "check_blas_num_threads" %}
+  run_constrained:
+    - blas=*=openblas  # [osx and x86_64]
 
 test:
   source_files:
@@ -47,12 +36,10 @@ test:
     - pip check
     - python -m threadpoolctl -i numpy
 
-    - pytest -v tests                              # [not (aarch64 or s390x or (osx and x86_64))]
+    - pytest -v tests                              # [not (aarch64 or s390x)]
     # linux-aarch64 (neoversen1) and s390x (z14) are unrecognized
     # architectures on Prefect.  linux-aarch64 (m1) is perfectly OK.
     - pytest -v tests -k 'not test_architecture'   # [aarch64 or s390x]
-    # osx-64 gets a dozen FAILURES
-    - pytest -v tests -k "not ({{ skip_tests }})"  # [osx and x86_64]
 
 about:
   home: https://github.com/joblib/threadpoolctl

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,17 +21,38 @@ requirements:
   run:
     - python
 
+{% set skip_tests = "" %}
+{% set skip_tests = skip_tests + "test_controller_info_actualized or " %}
+{% set skip_tests = skip_tests + "test_threadpool_limits_by_prefix or " %}
+{% set skip_tests = skip_tests + "test_threadpool_limits_by_prefix or " %}
+{% set skip_tests = skip_tests + "test_set_threadpool_limits_by_api or " %}
+{% set skip_tests = skip_tests + "test_threadpool_limits_function_with_side_effect or " %}
+{% set skip_tests = skip_tests + "test_threadpool_limits_manual_restore or " %}
+{% set skip_tests = skip_tests + "test_threadpool_controller_limit or " %}
+{% set skip_tests = skip_tests + "test_get_params_for_sequential_blas_under_openmp or " %}
+{% set skip_tests = skip_tests + "test_nested_limits or " %}
+{% set skip_tests = skip_tests + "test_threadpool_controller_as_decorator or " %}
+{% set skip_tests = skip_tests + "check_blas_num_threads" %}
+
 test:
   source_files:
     tests
   requires:
+    - pip
     - numpy
     - pytest
   imports:
     - threadpoolctl
   commands:
+    - pip check
     - python -m threadpoolctl -i numpy
-    - pytest -v tests
+
+    - pytest -v tests                              # [not (aarch64 or s390x or (osx and x86_64))]
+    # linux-aarch64 (neoversen1) and s390x (z14) are unrecognized
+    # architectures on Prefect.  linux-aarch64 (m1) is perfectly OK.
+    - pytest -v tests -k 'not test_architecture'   # [aarch64 or s390x]
+    # osx-64 gets a dozen FAILURES
+    - pytest -v tests -k "not ({{ skip_tests }})"  # [osx and x86_64]
 
 about:
   home: https://github.com/joblib/threadpoolctl

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,12 +23,16 @@ requirements:
     - python
 
 test:
+  source_files:
+    tests
   requires:
     - numpy
+    - pytest
   imports:
     - threadpoolctl
   commands:
     - python -m threadpoolctl -i numpy
+    - pytest -v tests
 
 about:
   home: https://github.com/joblib/threadpoolctl

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2.2.0" %}
+{% set version = "3.5.0" %}
 
 package:
   name: threadpoolctl
@@ -6,22 +6,21 @@ package:
 
 source:
   url: https://github.com/joblib/threadpoolctl/archive/{{ version }}.tar.gz
-  sha256: c61876ccd453f10c964d161272cbae165c2233cc5323ce0c3f544d8b8335fb9c
+  sha256: 3d941a397b35d15522d095173d06adeadc1d95f81f63b35e078e77b2d7c80401
 
 build:
+  skip: True  # [py<38]
   number: 0
-  noarch: python
   script:
     - FLIT_ROOT_INSTALL=1 {{ PYTHON }} -m flit install
 
 requirements:
   host:
-    - python >=3.6
-    - flit
-    - setuptools
+    - python
+    - flit >2,<4
     - wheel
   run:
-    - python >=3.6
+    - python
 
 test:
   requires:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -32,11 +32,10 @@ test:
 
 about:
   home: https://github.com/joblib/threadpoolctl
-  license: BSD 3-Clause
+  license: BSD-3-Clause
   license_family: BSD
   license_file: LICENSE
-  summary: 'Python helpers to control the threadpools of native libraries'
-
+  summary: Python helpers to control the threadpools of native libraries
   description: |
     Python helpers to introspect and limit the number of threads used
     in native libraries that handle their own internal threadpool

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,7 +18,6 @@ requirements:
     - python
     - pip
     - flit-core >2,<4
-    - wheel
   run:
     - python
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,8 +11,7 @@ source:
 build:
   skip: True  # [py<38]
   number: 0
-  script:
-    - FLIT_ROOT_INSTALL=1 {{ PYTHON }} -m flit install
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,7 +16,8 @@ build:
 requirements:
   host:
     - python
-    - flit >2,<4
+    - pip
+    - flit-core >2,<4
     - wheel
   run:
     - python


### PR DESCRIPTION
threadpoolctl 3.5.0 

**Destination channel:** Defaults

### Links

- [PKG-5068]
- dev_url:        https://github.com/joblib/threadpoolctl/tree/3.5.0
- conda_forge:    https://github.com/conda-forge/threadpoolctl-feedstock/blob/main/recipe/meta.yaml
- pypi:           https://pypi.org/project/threadpoolctl/3.5.0
- pypi inspector: https://inspector.pypi.io/project/threadpoolctl/3.5.0

### Explanation of changes:

- basic build
- add upstream tests
- `run_constrained` for `osx-64` to pull in `blas=*=openblas`
- skip `neoversen1` (`linux-aarch64`) and `z14` (`linux-s390x`) architecture tests (on Prefect)


[PKG-5068]: https://anaconda.atlassian.net/browse/PKG-5068?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ